### PR TITLE
Make tastypie-swagger compatible with Django 1.10

### DIFF
--- a/tastypie_swagger/urls.py
+++ b/tastypie_swagger/urls.py
@@ -1,13 +1,14 @@
 try:
-	from django.conf.urls import patterns, include, url
+    from django.conf.urls import url
 except ImportError:
-	from django.conf.urls.defaults import patterns, include, url
+    from django.conf.urls.defaults import url
 
 from .views import SwaggerView, ResourcesView, SchemaView
 
-urlpatterns = patterns('',
+
+urlpatterns = [
     url(r'^$', SwaggerView.as_view(), name='index'),
     url(r'^resources/$', ResourcesView.as_view(), name='resources'),
     url(r'^schema/(?P<resource>\S+)$', SchemaView.as_view()),
     url(r'^schema/$', SchemaView.as_view(), name='schema'),
-)
+]


### PR DESCRIPTION
Also removes ```2017-02-16 14:10:18,438 - WARNING - py.warnings - __init__.py:patterns:84 - RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead. [urls.py:12]```