### PR TITLE
Fix bug in Django 1.9 when using ListFields

### DIFF
--- a/tastypie_swagger/static/tastypie_swagger/js/lib/swagger.js
+++ b/tastypie_swagger/static/tastypie_swagger/js/lib/swagger.js
@@ -708,7 +708,7 @@ var SwaggerOperation = function(nickname, path, method, parameters, summary, not
 
     // for 1.1 compatibility
     var type = param.type || param.dataType;
-    if(type === 'array') {
+    if(type === 'array' && 'items' in param) {
       type = 'array[' + (param.items.$ref ? param.items.$ref : param.items.type) + ']';
     }
     param.type = type;


### PR DESCRIPTION
See https://github.com/marcgibbons/django-rest-swagger/pull/431 for more info

Before:
![swagger-fix-before](https://cloud.githubusercontent.com/assets/250780/23031582/6c408a82-f469-11e6-8866-53a9bcc8fc40.gif)
After:
![swagger-fix](https://cloud.githubusercontent.com/assets/250780/23031581/6c3f6c1a-f469-11e6-9b1a-d850d0e58763.gif)
